### PR TITLE
Update actions to current majors (Node 20 deprecation)

### DIFF
--- a/.github/workflows/build-and-archive-debian-package.yml
+++ b/.github/workflows/build-and-archive-debian-package.yml
@@ -21,7 +21,7 @@ jobs:
     
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: sbuild for ${{ matrix.distro }} ${{ matrix.arch }}
         uses: wlan-pi/sbuild-debian-package@main
@@ -31,7 +31,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Archive artifacts and upload to GitHub
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-misc-firmware-${{ matrix.distro }}-${{ matrix.arch }}
           path: ${{ steps.build-debian-package.outputs.deb-package }}

--- a/.github/workflows/deploy-to-packagecloud.yml
+++ b/.github/workflows/deploy-to-packagecloud.yml
@@ -26,7 +26,7 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v7
 
       - name: sbuild for ${{ matrix.distro }} ${{ matrix.arch }}
         uses: wlan-pi/sbuild-debian-package@main
@@ -36,7 +36,7 @@ jobs:
           arch: ${{ matrix.arch }}
 
       - name: Archive artifacts and upload to GitHub
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: wlanpi-misc-firmware-${{ matrix.distro }}-${{ matrix.arch }}
           path: ${{ steps.build-debian-package.outputs.deb-package }}


### PR DESCRIPTION
Part of the org-wide actions audit. Bumps outdated actions to current majors to clear the Node 20 deprecation warnings:

- actions/checkout to v7
- actions/upload-artifact to v7
- actions/cache to v6 (where used)
- actions/setup-python to v6 (where used)
- github/codeql-action to v4 (where used)

Workflow YAML validated. No behavior changes intended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
